### PR TITLE
UK Focus Tree BugFix

### DIFF
--- a/common/national_focus/uk.txt
+++ b/common/national_focus/uk.txt
@@ -4059,6 +4059,13 @@ focus_tree = {
 				}
 				navy_experience = 100
 				add_ideas = james_somerville
+
+				add_doctrine_cost_reduction = {
+					name = land_doc_bonus
+					cost_reduction = 0.5
+					uses = 3
+					category = naval_doctrine
+				}
 			}
 
 		}


### PR DESCRIPTION
Additional funding section was missing the 3x 50% naval doctrine bonus for Britannia Rules the Waves focus.