### PR TITLE
Moves the consumer goods bonus from USA's "Day of Infamy" into "Giant Wakes", stops USA's war economy focuses from being locked out

### DIFF
--- a/common/national_focus/usa.txt
+++ b/common/national_focus/usa.txt
@@ -713,7 +713,7 @@ focus_tree = {
 			show_ideas_tooltip = general_motors
 			add_to_variable = {
 				var = USA_consumer_goods_factor_var
-				value = -0.075
+				value = -0.100
 			}
 			custom_effect_tooltip = USA_11_tt
 			custom_effect_tooltip = USA_will_upgrade_all_one_step_tt
@@ -1161,7 +1161,7 @@ focus_tree = {
 			}
 			add_to_variable = {
 				var = USA_consumer_goods_factor_var
-				value = -0.025
+				value = -0.050
 			}
 			add_days_mission_timeout = {
 				mission = USA_federal_housing_act_mission
@@ -1372,12 +1372,9 @@ focus_tree = {
 			always = no
 		}
 		bypass = {
+			has_war_with = JAP
 		}
 		completion_reward = {
-			add_to_variable = {
-				var = USA_consumer_goods_factor_var
-				value = -0.025
-			}
 			GER = {
 				declare_war_on = {
 					target = USA


### PR DESCRIPTION
QT implemented my suggestion of making "Day of Infamy" by making it nonbypassable so USA can make usage of the -2.5% consumer goods bonus by manually starting and completing the focus, although this also means the focus can never be started and there doesn't seem to be an obviously way of it being auto completed so USA is locked out of it's war economy focus tree (and not even being able to access the consumer goods reduction)

This PR will make "Day of Infamy" bypassed when at war with Japan again; following the trend of 0 day focuses are to be always bypassed and never started, alongside making the -2.5% consumer goods buff be accessible by either "Giant Wakes" focus as they are both possible to start when at war with Japan.

Technically the -2.5% consumer goods bonus is accessible by 1938 with right side economy tree rather than at war with Japan; modify the PR if you don't want that to be a thing