### PR TITLE
CAN-Remove Starting Torp 3

### DIFF
--- a/history/countries/CAN - Canada.txt
+++ b/history/countries/CAN - Canada.txt
@@ -334,7 +334,7 @@ if = {
 			fixed_ship_armor_slot = ship_armor_cruiser_2
 			fixed_ship_secondaries_slot = dp_ship_secondaries
 			front_1_custom_slot = ship_light_medium_battery_2
-			mid_1_custom_slot = ship_torpedo_3
+			mid_1_custom_slot = ship_torpedo_2
 			mid_2_custom_slot = ship_light_medium_battery_2
 			rear_1_custom_slot = ship_light_medium_battery_2
 		}


### PR DESCRIPTION
Remove Torpedo 3 from Canada as starting tech.